### PR TITLE
Some modernisation of QtPropertyBrowser

### DIFF
--- a/src/qtbuttonpropertybrowser.cpp
+++ b/src/qtbuttonpropertybrowser.cpp
@@ -235,9 +235,9 @@ void QtButtonPropertyBrowserPrivate::slotToggled(bool checked)
     setExpanded(item, checked);
 
     if (checked)
-        emit q_ptr->expanded(m_itemToIndex.value(item));
+        Q_EMIT q_ptr->expanded(m_itemToIndex.value(item));
     else
-        emit q_ptr->collapsed(m_itemToIndex.value(item));
+        Q_EMIT q_ptr->collapsed(m_itemToIndex.value(item));
 }
 
 void QtButtonPropertyBrowserPrivate::updateLater()

--- a/src/qteditorfactory.cpp
+++ b/src/qteditorfactory.cpp
@@ -1531,7 +1531,7 @@ protected:
     void keyReleaseEvent(QKeyEvent *e);
     void paintEvent(QPaintEvent *);
     bool event(QEvent *e);
-private slots:
+private Q_SLOTS:
     void slotClearChar();
 private:
     void handleKeyEvent(QKeyEvent *e);
@@ -1591,7 +1591,7 @@ void QtCharEdit::slotClearChar()
     if (m_value.isNull())
         return;
     setValue(QChar());
-    emit valueChanged(m_value);
+    Q_EMIT valueChanged(m_value);
 }
 
 void QtCharEdit::handleKeyEvent(QKeyEvent *e)
@@ -1624,7 +1624,7 @@ void QtCharEdit::handleKeyEvent(QKeyEvent *e)
     const QString str = m_value.isNull() ? QString() : QString(m_value);
     m_lineEdit->setText(str);
     e->accept();
-    emit valueChanged(m_value);
+    Q_EMIT valueChanged(m_value);
 }
 
 void QtCharEdit::setValue(const QChar &value)
@@ -2432,7 +2432,7 @@ void QtFontEditWidget::buttonClicked()
         if (m_font.strikeOut() != newFont.strikeOut())
             f.setStrikeOut(newFont.strikeOut());
         setValue(f);
-        emit valueChanged(m_font);
+        Q_EMIT valueChanged(m_font);
     }
 }
 

--- a/src/qteditorfactory.cpp
+++ b/src/qteditorfactory.cpp
@@ -2205,12 +2205,10 @@ void QtColorEditWidget::setValue(const QColor &c)
 
 void QtColorEditWidget::buttonClicked()
 {
-    bool ok = false;
-    QRgb oldRgba = m_color.rgba();
-    QRgb newRgba = QColorDialog::getRgba(oldRgba, &ok, this);
-    if (ok && newRgba != oldRgba) {
-        setValue(QColor::fromRgba(newRgba));
-        emit valueChanged(m_color);
+    QColor newColor = QColorDialog::getColor(m_color, this);
+    if (newColor != m_color) {
+        setValue(newColor);
+        Q_EMIT valueChanged(m_color);
     }
 }
 

--- a/src/qtpropertybrowser.cpp
+++ b/src/qtpropertybrowser.cpp
@@ -543,7 +543,7 @@ void QtProperty::propertyChanged()
 void QtAbstractPropertyManagerPrivate::propertyDestroyed(QtProperty *property)
 {
     if (m_properties.contains(property)) {
-        emit q_ptr->propertyDestroyed(property);
+        Q_EMIT q_ptr->propertyDestroyed(property);
         q_ptr->uninitializeProperty(property);
         m_properties.remove(property);
     }
@@ -551,19 +551,19 @@ void QtAbstractPropertyManagerPrivate::propertyDestroyed(QtProperty *property)
 
 void QtAbstractPropertyManagerPrivate::propertyChanged(QtProperty *property) const
 {
-    emit q_ptr->propertyChanged(property);
+    Q_EMIT q_ptr->propertyChanged(property);
 }
 
 void QtAbstractPropertyManagerPrivate::propertyRemoved(QtProperty *property,
             QtProperty *parentProperty) const
 {
-    emit q_ptr->propertyRemoved(property, parentProperty);
+    Q_EMIT q_ptr->propertyRemoved(property, parentProperty);
 }
 
 void QtAbstractPropertyManagerPrivate::propertyInserted(QtProperty *property,
             QtProperty *parentProperty, QtProperty *afterProperty) const
 {
-    emit q_ptr->propertyInserted(property, parentProperty, afterProperty);
+    Q_EMIT q_ptr->propertyInserted(property, parentProperty, afterProperty);
 }
 
 /*!
@@ -793,7 +793,7 @@ QtProperty *QtAbstractPropertyManager::addProperty(const QString &name)
 */
 QtProperty * QtAbstractPropertyManager::qtProperty(const QString &id)const
 {
-  foreach(QtProperty* prop, d_ptr->m_properties)
+  Q_FOREACH(QtProperty* prop, d_ptr->m_properties)
     {
     if (prop->propertyId() == id)
       {
@@ -2038,7 +2038,7 @@ void QtAbstractPropertyBrowser::setCurrentItem(QtBrowserItem *item)
     QtBrowserItem *oldItem = d_ptr->m_currentItem;
     d_ptr->m_currentItem = item;
     if (oldItem != item)
-        emit  currentItemChanged(item);
+        Q_EMIT currentItemChanged(item);
 }
 
 #if QT_VERSION >= 0x040400

--- a/src/qtpropertybrowserutils.cpp
+++ b/src/qtpropertybrowserutils.cpp
@@ -320,7 +320,7 @@ void QtKeySequenceEdit::slotClearShortcut()
     if (m_keySequence.isEmpty())
         return;
     setKeySequence(QKeySequence());
-    emit keySequenceChanged(m_keySequence);
+    Q_EMIT keySequenceChanged(m_keySequence);
 }
 
 void QtKeySequenceEdit::handleKeyEvent(QKeyEvent *e)
@@ -349,7 +349,7 @@ void QtKeySequenceEdit::handleKeyEvent(QKeyEvent *e)
     m_keySequence = QKeySequence(k0, k1, k2, k3);
     m_lineEdit->setText(m_keySequence.toString(QKeySequence::NativeText));
     e->accept();
-    emit keySequenceChanged(m_keySequence);
+    Q_EMIT keySequenceChanged(m_keySequence);
 }
 
 void QtKeySequenceEdit::setKeySequence(const QKeySequence &sequence)

--- a/src/qtpropertybrowserutils_p.h
+++ b/src/qtpropertybrowserutils_p.h
@@ -144,7 +144,7 @@ protected:
     void keyReleaseEvent(QKeyEvent *e);
     void paintEvent(QPaintEvent *);
     bool event(QEvent *e);
-private slots:
+private Q_SLOTS:
     void slotClearShortcut();
 private:
     void handleKeyEvent(QKeyEvent *e);

--- a/src/qtpropertymanager.cpp
+++ b/src/qtpropertymanager.cpp
@@ -238,8 +238,8 @@ static void setSimpleValue(QMap<const QtProperty *, Value> &propertyMap,
 
     it.value() = val;
 
-    emit (manager->*propertyChangedSignal)(property);
-    emit (manager->*valueChangedSignal)(property, val);
+    Q_EMIT (manager->*propertyChangedSignal)(property);
+    Q_EMIT (manager->*valueChangedSignal)(property, val);
 }
 
 template <class ValueChangeParameter, class PropertyManagerPrivate, class PropertyManager, class Value>
@@ -271,8 +271,8 @@ static void setValueInRange(PropertyManager *manager, PropertyManagerPrivate *ma
     if (setSubPropertyValue)
         (managerPrivate->*setSubPropertyValue)(property, data.val);
 
-    emit (manager->*propertyChangedSignal)(property);
-    emit (manager->*valueChangedSignal)(property, data.val);
+    Q_EMIT (manager->*propertyChangedSignal)(property);
+    Q_EMIT (manager->*valueChangedSignal)(property, data.val);
 }
 
 template <class ValueChangeParameter, class PropertyManagerPrivate, class PropertyManager, class Value>
@@ -305,7 +305,7 @@ static void setBorderValues(PropertyManager *manager, PropertyManagerPrivate *ma
     data.setMinimumValue(fromVal);
     data.setMaximumValue(toVal);
 
-    emit (manager->*rangeChangedSignal)(property, data.minVal, data.maxVal);
+    Q_EMIT (manager->*rangeChangedSignal)(property, data.minVal, data.maxVal);
 
     if (setSubPropertyRange)
         (managerPrivate->*setSubPropertyRange)(property, data.minVal, data.maxVal, data.val);
@@ -313,8 +313,8 @@ static void setBorderValues(PropertyManager *manager, PropertyManagerPrivate *ma
     if (data.val == oldVal)
         return;
 
-    emit (manager->*propertyChangedSignal)(property);
-    emit (manager->*valueChangedSignal)(property, data.val);
+    Q_EMIT (manager->*propertyChangedSignal)(property);
+    Q_EMIT (manager->*valueChangedSignal)(property, data.val);
 }
 
 template <class ValueChangeParameter, class PropertyManagerPrivate, class PropertyManager, class Value, class PrivateData>
@@ -343,7 +343,7 @@ static void setBorderValue(PropertyManager *manager, PropertyManagerPrivate *man
 
     (data.*setRangeVal)(borderVal);
 
-    emit (manager->*rangeChangedSignal)(property, data.minVal, data.maxVal);
+    Q_EMIT (manager->*rangeChangedSignal)(property, data.minVal, data.maxVal);
 
     if (setSubPropertyRange)
         (managerPrivate->*setSubPropertyRange)(property, data.minVal, data.maxVal, data.val);
@@ -351,8 +351,8 @@ static void setBorderValue(PropertyManager *manager, PropertyManagerPrivate *man
     if (data.val == oldVal)
         return;
 
-    emit (manager->*propertyChangedSignal)(property);
-    emit (manager->*valueChangedSignal)(property, data.val);
+    Q_EMIT (manager->*propertyChangedSignal)(property);
+    Q_EMIT (manager->*valueChangedSignal)(property, data.val);
 }
 
 template <class ValueChangeParameter, class PropertyManagerPrivate, class PropertyManager, class Value, class PrivateData>
@@ -870,7 +870,7 @@ void QtIntPropertyManager::setSingleStep(QtProperty *property, int step)
 
     it.value() = data;
 
-    emit singleStepChanged(property, data.singleStep);
+    Q_EMIT singleStepChanged(property, data.singleStep);
 }
 
 /*!
@@ -1108,7 +1108,7 @@ void QtDoublePropertyManager::setSingleStep(QtProperty *property, double step)
 
     it.value() = data;
 
-    emit singleStepChanged(property, data.singleStep);
+    Q_EMIT singleStepChanged(property, data.singleStep);
 }
 
 /*!
@@ -1140,7 +1140,7 @@ void QtDoublePropertyManager::setDecimals(QtProperty *property, int prec)
 
     it.value() = data;
 
-    emit decimalsChanged(property, data.decimals);
+    Q_EMIT decimalsChanged(property, data.decimals);
 }
 
 /*!
@@ -1364,8 +1364,8 @@ void QtStringPropertyManager::setValue(QtProperty *property, const QString &val)
 
     it.value() = data;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -1388,7 +1388,7 @@ void QtStringPropertyManager::setRegExp(QtProperty *property, const QRegExp &reg
 
     it.value() = data;
 
-    emit regExpChanged(property, data.regExp);
+    Q_EMIT regExpChanged(property, data.regExp);
 }
 
 /*!
@@ -2438,8 +2438,8 @@ void QtLocalePropertyManager::setValue(QtProperty *property, const QLocale &val)
     }
     d_ptr->m_enumPropertyManager->setValue(d_ptr->m_propertyToCountry.value(property), countryIdx);
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -2657,8 +2657,8 @@ void QtPointPropertyManager::setValue(QtProperty *property, const QPoint &val)
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToX[property], val.x());
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToY[property], val.y());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -2897,8 +2897,8 @@ void QtPointFPropertyManager::setValue(QtProperty *property, const QPointF &val)
     d_ptr->m_doublePropertyManager->setValue(d_ptr->m_propertyToX[property], val.x());
     d_ptr->m_doublePropertyManager->setValue(d_ptr->m_propertyToY[property], val.y());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -2932,7 +2932,7 @@ void QtPointFPropertyManager::setDecimals(QtProperty *property, int prec)
 
     it.value() = data;
 
-    emit decimalsChanged(property, data.decimals);
+    Q_EMIT decimalsChanged(property, data.decimals);
 }
 
 /*!
@@ -3609,7 +3609,7 @@ void QtSizeFPropertyManager::setDecimals(QtProperty *property, int prec)
 
     it.value() = data;
 
-    emit decimalsChanged(property, data.decimals);
+    Q_EMIT decimalsChanged(property, data.decimals);
 }
 
 /*!
@@ -3996,8 +3996,8 @@ void QtRectPropertyManager::setValue(QtProperty *property, const QRect &val)
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToW[property], newRect.width());
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToH[property], newRect.height());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4048,15 +4048,15 @@ void QtRectPropertyManager::setConstraint(QtProperty *property, const QRect &con
 
     it.value() = data;
 
-    emit constraintChanged(property, data.constraint);
+    Q_EMIT constraintChanged(property, data.constraint);
 
     d_ptr->setConstraint(property, data.constraint, data.val);
 
     if (data.val == oldVal)
         return;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4426,8 +4426,8 @@ void QtRectFPropertyManager::setValue(QtProperty *property, const QRectF &val)
     d_ptr->m_doublePropertyManager->setValue(d_ptr->m_propertyToW[property], newRect.width());
     d_ptr->m_doublePropertyManager->setValue(d_ptr->m_propertyToH[property], newRect.height());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4478,15 +4478,15 @@ void QtRectFPropertyManager::setConstraint(QtProperty *property, const QRectF &c
 
     it.value() = data;
 
-    emit constraintChanged(property, data.constraint);
+    Q_EMIT constraintChanged(property, data.constraint);
 
     d_ptr->setConstraint(property, data.constraint, data.val);
 
     if (data.val == oldVal)
         return;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4522,7 +4522,7 @@ void QtRectFPropertyManager::setDecimals(QtProperty *property, int prec)
 
     it.value() = data;
 
-    emit decimalsChanged(property, data.decimals);
+    Q_EMIT decimalsChanged(property, data.decimals);
 }
 
 /*!
@@ -4795,8 +4795,8 @@ void QtEnumPropertyManager::setValue(QtProperty *property, int val)
 
     it.value() = data;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4829,10 +4829,10 @@ void QtEnumPropertyManager::setEnumNames(QtProperty *property, const QStringList
 
     it.value() = data;
 
-    emit enumNamesChanged(property, data.enumNames);
+    Q_EMIT enumNamesChanged(property, data.enumNames);
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -4851,9 +4851,9 @@ void QtEnumPropertyManager::setEnumIcons(QtProperty *property, const QMap<int, Q
 
     it.value().enumIcons = enumIcons;
 
-    emit enumIconsChanged(property, it.value().enumIcons);
+    Q_EMIT enumIconsChanged(property, it.value().enumIcons);
 
-    emit propertyChanged(property);
+    Q_EMIT propertyChanged(property);
 }
 
 /*!
@@ -5118,8 +5118,8 @@ void QtFlagPropertyManager::setValue(QtProperty *property, int val)
         level++;
     }
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -5165,10 +5165,10 @@ void QtFlagPropertyManager::setFlagNames(QtProperty *property, const QStringList
         d_ptr->m_flagToProperty[prop] = property;
     }
 
-    emit flagNamesChanged(property, data.flagNames);
+    Q_EMIT flagNamesChanged(property, data.flagNames);
 
-    emit propertyChanged(property);
-    emit valueChanged(property, data.val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, data.val);
 }
 
 /*!
@@ -5432,8 +5432,8 @@ void QtSizePolicyPropertyManager::setValue(QtProperty *property, const QSizePoli
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToVStretch[property],
                 val.verticalStretch());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -5873,8 +5873,8 @@ void QtFontPropertyManager::setValue(QtProperty *property, const QFont &val)
     d_ptr->m_boolPropertyManager->setValue(d_ptr->m_propertyToKerning[property], val.kerning());
     d_ptr->m_settingValue = settingValue;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -6199,8 +6199,8 @@ void QtColorPropertyManager::setValue(QtProperty *property, const QColor &val)
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToB[property], val.blue());
     d_ptr->m_intPropertyManager->setValue(d_ptr->m_propertyToA[property], val.alpha());
 
-    emit propertyChanged(property);
-    emit valueChanged(property, val);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, val);
 }
 
 /*!
@@ -6394,8 +6394,8 @@ void QtCursorPropertyManager::setValue(QtProperty *property, const QCursor &valu
 
     it.value() = value;
 
-    emit propertyChanged(property);
-    emit valueChanged(property, value);
+    Q_EMIT propertyChanged(property);
+    Q_EMIT valueChanged(property, value);
 #endif
 }
 

--- a/src/qttreepropertybrowser.cpp
+++ b/src/qttreepropertybrowser.cpp
@@ -254,7 +254,7 @@ protected:
     void drawDisplay(QPainter *painter, const QStyleOptionViewItem &option,
             const QRect &rect, const QString &text) const;
 
-private slots:
+private Q_SLOTS:
     void slotEditorDestroyed(QObject *object);
 
 private:
@@ -671,7 +671,7 @@ void QtTreePropertyBrowserPrivate::slotCollapsed(const QModelIndex &index)
     QTreeWidgetItem *item = indexToItem(index);
     QtBrowserItem *idx = m_itemToIndex.value(item);
     if (item)
-        emit q_ptr->collapsed(idx);
+        Q_EMIT q_ptr->collapsed(idx);
 }
 
 void QtTreePropertyBrowserPrivate::slotExpanded(const QModelIndex &index)
@@ -679,7 +679,7 @@ void QtTreePropertyBrowserPrivate::slotExpanded(const QModelIndex &index)
     QTreeWidgetItem *item = indexToItem(index);
     QtBrowserItem *idx = m_itemToIndex.value(item);
     if (item)
-        emit q_ptr->expanded(idx);
+        Q_EMIT q_ptr->expanded(idx);
 }
 
 void QtTreePropertyBrowserPrivate::slotCurrentBrowserItemChanged(QtBrowserItem *item)

--- a/src/qtvariantproperty.cpp
+++ b/src/qtvariantproperty.cpp
@@ -486,8 +486,8 @@ void QtVariantPropertyManagerPrivate::valueChanged(QtProperty *property, const Q
     QtVariantProperty *varProp = m_internalToProperty.value(property, 0);
     if (!varProp)
         return;
-    emit q_ptr->valueChanged(varProp, val);
-    emit q_ptr->propertyChanged(varProp);
+    Q_EMIT q_ptr->valueChanged(varProp, val);
+    Q_EMIT q_ptr->propertyChanged(varProp);
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, int val)
@@ -498,15 +498,15 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, int
 void QtVariantPropertyManagerPrivate::slotRangeChanged(QtProperty *property, int min, int max)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
-        emit q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
-        emit q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
     }
 }
 
 void QtVariantPropertyManagerPrivate::slotSingleStepChanged(QtProperty *property, int step)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_singleStepAttribute, QVariant(step));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_singleStepAttribute, QVariant(step));
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, double val)
@@ -517,21 +517,21 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, dou
 void QtVariantPropertyManagerPrivate::slotRangeChanged(QtProperty *property, double min, double max)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
-        emit q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
-        emit q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
     }
 }
 
 void QtVariantPropertyManagerPrivate::slotSingleStepChanged(QtProperty *property, double step)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_singleStepAttribute, QVariant(step));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_singleStepAttribute, QVariant(step));
 }
 
 void QtVariantPropertyManagerPrivate::slotDecimalsChanged(QtProperty *property, int prec)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_decimalsAttribute, QVariant(prec));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_decimalsAttribute, QVariant(prec));
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, bool val)
@@ -547,7 +547,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotRegExpChanged(QtProperty *property, const QRegExp &regExp)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_regExpAttribute, QVariant(regExp));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_regExpAttribute, QVariant(regExp));
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, const QDate &val)
@@ -558,8 +558,8 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotRangeChanged(QtProperty *property, const QDate &min, const QDate &max)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
-        emit q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
-        emit q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
     }
 }
 
@@ -608,8 +608,8 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotRangeChanged(QtProperty *property, const QSize &min, const QSize &max)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
-        emit q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
-        emit q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
     }
 }
 
@@ -621,8 +621,8 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotRangeChanged(QtProperty *property, const QSizeF &min, const QSizeF &max)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
-        emit q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
-        emit q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_minimumAttribute, QVariant(min));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_maximumAttribute, QVariant(max));
     }
 }
 
@@ -634,7 +634,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotConstraintChanged(QtProperty *property, const QRect &constraint)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_constraintAttribute, QVariant(constraint));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_constraintAttribute, QVariant(constraint));
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, const QRectF &val)
@@ -645,7 +645,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotConstraintChanged(QtProperty *property, const QRectF &constraint)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_constraintAttribute, QVariant(constraint));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_constraintAttribute, QVariant(constraint));
 }
 
 void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, const QColor &val)
@@ -656,7 +656,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotEnumNamesChanged(QtProperty *property, const QStringList &enumNames)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_enumNamesAttribute, QVariant(enumNames));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_enumNamesAttribute, QVariant(enumNames));
 }
 
 void QtVariantPropertyManagerPrivate::slotEnumIconsChanged(QtProperty *property, const QMap<int, QIcon> &enumIcons)
@@ -664,7 +664,7 @@ void QtVariantPropertyManagerPrivate::slotEnumIconsChanged(QtProperty *property,
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0)) {
         QVariant v;
         qVariantSetValue(v, enumIcons);
-        emit q_ptr->attributeChanged(varProp, m_enumIconsAttribute, v);
+        Q_EMIT q_ptr->attributeChanged(varProp, m_enumIconsAttribute, v);
     }
 }
 
@@ -688,7 +688,7 @@ void QtVariantPropertyManagerPrivate::slotValueChanged(QtProperty *property, con
 void QtVariantPropertyManagerPrivate::slotFlagNamesChanged(QtProperty *property, const QStringList &flagNames)
 {
     if (QtVariantProperty *varProp = m_internalToProperty.value(property, 0))
-        emit q_ptr->attributeChanged(varProp, m_flagNamesAttribute, QVariant(flagNames));
+        Q_EMIT q_ptr->attributeChanged(varProp, m_flagNamesAttribute, QVariant(flagNames));
 }
 
 /*!
@@ -1330,7 +1330,7 @@ void addPropertyRecusively(QtVariantPropertyManager * manager,
     }
   // Copy values
   QStringList attributes = manager->attributes(prop->propertyType());
-  foreach(const QString& attribute, attributes)
+  Q_FOREACH(const QString& attribute, attributes)
     {
     newProp->setAttribute(attribute, prop->attributeValue(attribute));
     }
@@ -1341,7 +1341,7 @@ void addPropertyRecusively(QtVariantPropertyManager * manager,
   newProp->setEnabled(prop->isEnabled());
   newProp->setValue(prop->value());
 
-  foreach(QtProperty * subProp, prop->subProperties())
+  Q_FOREACH(QtProperty * subProp, prop->subProperties())
     {
     QtVariantProperty * variantSubProp = dynamic_cast<QtVariantProperty*>(subProp);
     Q_ASSERT(variantSubProp);
@@ -1361,7 +1361,7 @@ void addPropertyRecusively(QtVariantPropertyManager * manager,
 void QtVariantPropertyManager::setProperties(QSet<QtProperty *> properties)
 {
   this->clear();
-  foreach(QtProperty * prop, properties)
+  Q_FOREACH(QtProperty * prop, properties)
     {
     QtVariantProperty * variantProp = dynamic_cast<QtVariantProperty*>(prop);
     if (!variantProp){ continue; }


### PR DESCRIPTION
I'm starting to use QtPropertyBrowser on a new project and ran into a couple of problems. We compile with CONFIG = no_keywords, so I replaced emit, foreach and slots with their Q_ macro equivalents, which also work if no_keywords hasn't been defined. I also replaced use of the obsolete method QColorDialog::getRgba() with QColorDialog::getColor(). It's been available since Qt 4.5 so should be OK to use and it's cleaner in this use case.